### PR TITLE
Fixes for modern perl versions

### DIFF
--- a/Tail.xs
+++ b/Tail.xs
@@ -81,7 +81,8 @@ goto_entersub (pTHX) {
                 if (!sym)
                     DIE(aTHX_ PL_no_usym, "a subroutine");
                 if (PL_op->op_private & HINT_STRICT_REFS)
-                    DIE(aTHX_ PL_no_symref, sym, "a subroutine");
+                    DIE(aTHX_ "Can't use string (\"%.32s\") as %s ref while \"strict refs\" in use",
+                        sym, "a subroutine");
                 cv = get_cv(sym, GV_ADD|SvUTF8(sv));
                 break;
             }

--- a/Tail.xs
+++ b/Tail.xs
@@ -142,7 +142,11 @@ try_autoload:
      * entersub. We set it up so that defgv is pointing at the pushed args as
      * set up by the entersub call, this will let pp_goto work unmodified */
 
+#if PERL_VERSION_GE(5,23,8)
+    av = MUTABLE_AV(PAD_SVl(0));
+#else
     av = cx->blk_sub.argarray;
+#endif
 
     /* abandon @_ if it got reified */
     if (AvREAL(av)) {
@@ -150,7 +154,9 @@ try_autoload:
         av = newAV();
         AvREIFY_only(av);
 
+#if PERL_VERSION_LT(5,23,8)
         cx->blk_sub.argarray = av;
+#endif
         PAD_SVl(0) = (SV *)av;
     }
 


### PR DESCRIPTION
This fixes some issues relating to newer perl releases. Specifically, removing the use of `blk_sub.argarray` and `op_sibling`, which no longer exist.

This should be reviewed by someone with more familiarity with optree manipulation and such, as this is not my area of expertise.